### PR TITLE
Update regular expression pattern

### DIFF
--- a/src/main/java/com/statful/mapper/DefaultMappingProcessor.java
+++ b/src/main/java/com/statful/mapper/DefaultMappingProcessor.java
@@ -107,7 +107,7 @@ public class DefaultMappingProcessor implements MappingProcessor<DefaultEvent> {
         return Pattern.compile(
                 globedMatch
                         .replace(".", "\\.")
-                        .replace("*", "[a-zA-Z_]+")
+                        .replace("*", "[a-zA-Z0-9_-]+")
         ).matcher(metric).matches();
     }
 }


### PR DESCRIPTION
Newest versions os Ambassador (at least 0.82.0) have metrics with a new pattern that can include numbers and also the '-' (dash) character. So that those metrics can be processed as well, the regular expression to match metrics needs to be updated.